### PR TITLE
Fix and add ability to override license in generated metadata.json

### DIFF
--- a/skeleton/tasks/templates/metadata.json.erb
+++ b/skeleton/tasks/templates/metadata.json.erb
@@ -3,7 +3,7 @@
   "version": "<%= metadata['version'] %>",
   "author": "itv",
   "summary": "<%= metadata['description'] %>",
-  "license": "Apache 2.0",
+  "license": "<%= metadata['license'] or 'Apache-2.0' %>",
   "source": "<%= metadata['git_url'] %>",
   "description": "<%= metadata['description'] %>",
   "project_page": "<%= metadata['git_url'] %>",


### PR DESCRIPTION
Currently running metadataljson-lint on the generated metadata.json file causes our rake task to fail: 
```
metadata-json-lint metadata.json
Warning: License identifier Apache 2.0 is not in the SPDX list: http://spdx.org/licenses/
Errors found in metadata.json
```

This PR addresses that issue and adds the ability to specify your own license in your itv.yaml if desired. Like:

```
license: 'Unlicense'
```